### PR TITLE
feat: use two deploy branches for CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,6 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.8.8'
+
 pipeline {
   agent { label 'linux' }
 
@@ -13,42 +16,30 @@ pipeline {
   environment {
     GIT_COMMITTER_NAME = 'status-im-auto'
     GIT_COMMITTER_EMAIL = 'auto@status.im'
-    PROD_SITE = 'blog.waku.org'
-    DEV_SITE  = 'dev-blog.waku.org'
-    DEV_HOST  = 'jenkins@node-01.do-ams3.sites.misc.statusim.net'
-    SCP_OPTS  = 'StrictHostKeyChecking=no'
   }
 
   stages {
     stage('Install') {
       steps {
-        sh "yarn install"
+        sh 'yarn install'
       }
     }
 
     stage('Build') {
-      steps {
+      steps { script {
         sh 'yarn build'
-        sh "echo ${env.PROD_SITE} > build/CNAME"
-      }
+        jenkins.genBuildMetaJSON('build/build.json')
+      } }
     }
 
-    stage('Publish Prod') {
-      when { expression { env.GIT_BRANCH ==~ /.*master/ } }
+    stage('Publish') {
       steps {
         sshagent(credentials: ['status-im-auto-ssh']) {
-          sh "ghp-import -p build"
-        }
-      }
-    }
-
-    stage('Publish Devel') {
-      when { expression { env.GIT_BRANCH ==~ /.*develop/ } }
-      steps {
-        sshagent(credentials: ['jenkins-ssh']) {
           sh """
-            rsync -e 'ssh -o ${SCP_OPTS}' -r --delete build/. \
-              ${env.DEV_HOST}:/var/www/${env.DEV_SITE}/
+            ghp-import \
+              -b ${deployBranch()} \
+              -c ${deployDomain()} \
+              -p build
           """
         }
       }
@@ -59,3 +50,7 @@ pipeline {
     cleanup { cleanWs() }
   }
 }
+
+def isMasterBranch() { GIT_BRANCH ==~ /.*master/ }
+def deployBranch() { isMasterBranch() ? 'deploy-master' : 'deploy-develop' }
+def deployDomain() { isMasterBranch() ? 'blog.waku.org' : 'dev-blog.waku.org' }

--- a/README.md
+++ b/README.md
@@ -63,8 +63,12 @@ You can find instructions for adding additional documentation sections, implemen
 
 ## CI/CD
 
-- The `master` branch is deployed to https://blog.waku.org/ through [Jenkins CI](https://ci.infra.status.im/job/website/job/blog.waku.org/).
-- The `develop` branch is deployed to https://dev-blog.waku.org/ through [Jenkins CI](https://ci.infra.status.im/job/website/job/dev-blog.waku.org/).
+- [CI builds](https://ci.infra.status.im/job/website/job/blog.waku.org/) `master` and pushes to `deploy-master` branch, which is hosted at <https://blog.waku.org/>.
+- [CI builds](https://ci.infra.status.im/job/website/job/dev-blog.waku.org/) `develop` and pushes to `deploy-develop` branch, which is hosted at <https://dev-blog.waku.org/>.
+
+The hosting is done using [Caddy server with Git plugin for handling GitHub webhooks](https://github.com/status-im/infra-misc/blob/master/ansible/roles/caddy-git).
+
+Information about deployed build can be also found in `/build.json` available on the website.
 
 ## Change Process
 


### PR DESCRIPTION
This way we have two branches on GitHub that reflect the state of the website after CI build has finished and pushed. See README.

Also adds `/build.json` to the site for easy access to build info.