### PR TITLE
FIx typo

### DIFF
--- a/posts/2024-05-13-the-graph-case-study.mdx
+++ b/posts/2024-05-13-the-graph-case-study.mdx
@@ -74,7 +74,7 @@ Before the GraphOps team introduced GraphCast, the majority of the indexing solu
 **2. Old-fashioned group chat:** It is highly dependent on Web2 communications, which have a single point of failure and higher security risks.
 
 **3. Automated bots:** Several indexer bots running on centralised servers to automate communication on event signalling.
-All the three solutions listed above could have been more efficient. Hence, we wanted a more robust and decentralised communications infrastructure to fix several issues. The core contributors of GraphOps mention that Waku is an obvious choice for solving this problem. Continue reading to learn more about how GraphCast uses Waku.
+All three solutions listed above could have been more efficient. Hence, we wanted a more robust and decentralised communications infrastructure to fix several issues. The core contributors of GraphOps mention that Waku is an obvious choice for solving this problem. Continue reading to learn more about how GraphCast uses Waku.
 
 ## How does The Graph use Waku?
 


### PR DESCRIPTION
Update from: All the three solutions listed above could have been more efficient.
to: All three solutions listed above could have been more efficient.